### PR TITLE
Update dependency to bufbuild/connect-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/bufbuild/connect-grpchealth-go
 go 1.18
 
 require (
-	github.com/bufbuild/connect v0.0.0-20220318230559-bc1698b81efc
+	github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8
 	google.golang.org/protobuf v1.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bufbuild/connect v0.0.0-20220318230559-bc1698b81efc h1:VzpHAjYCg2mLYNNs6FGOEyFUTiwdOHKSJsXSPd0orWI=
 github.com/bufbuild/connect v0.0.0-20220318230559-bc1698b81efc/go.mod h1:1AuJLSE0NR4+fLrzIF/lrOQkWWyWjv2NWWig2BMX9F8=
+github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8 h1:ZaD9cVYESl0sBAvcpmSO4wRbOSwS32F5wNPrnDw1XdE=
+github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8/go.mod h1:BajZGyRXK+Oq6Ddkm7atQ1Tu4W92OMpam7vyhFIf0ww=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/bufbuild/connect v0.0.0-20220318230559-bc1698b81efc h1:VzpHAjYCg2mLYNNs6FGOEyFUTiwdOHKSJsXSPd0orWI=
-github.com/bufbuild/connect v0.0.0-20220318230559-bc1698b81efc/go.mod h1:1AuJLSE0NR4+fLrzIF/lrOQkWWyWjv2NWWig2BMX9F8=
 github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8 h1:ZaD9cVYESl0sBAvcpmSO4wRbOSwS32F5wNPrnDw1XdE=
 github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8/go.mod h1:BajZGyRXK+Oq6Ddkm7atQ1Tu4W92OMpam7vyhFIf0ww=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=

--- a/grpchealth.go
+++ b/grpchealth.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/bufbuild/connect"
+	"github.com/bufbuild/connect-go"
 	healthv1 "github.com/bufbuild/connect-grpchealth-go/internal/gen/go/connectext/grpc/health/v1"
 )
 

--- a/grpchealth_test.go
+++ b/grpchealth_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/bufbuild/connect"
+	"github.com/bufbuild/connect-go"
 	healthv1 "github.com/bufbuild/connect-grpchealth-go/internal/gen/go/connectext/grpc/health/v1"
 )
 
@@ -39,14 +39,11 @@ func TestHealth(t *testing.T) {
 	server.StartTLS()
 	defer server.Close()
 
-	client, err := connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
+	client := connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
 		server.Client(),
 		server.URL+"/grpc.health.v1.Health/Check",
 		connect.WithGRPC(),
 	)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
 
 	t.Run("process", func(t *testing.T) { // nolint: paralleltest
 		res, err := client.CallUnary(
@@ -89,14 +86,11 @@ func TestHealth(t *testing.T) {
 		}
 	})
 	t.Run("watch", func(t *testing.T) { // nolint: paralleltest
-		client, err := connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
+		client := connect.NewClient[healthv1.HealthCheckRequest, healthv1.HealthCheckResponse](
 			server.Client(),
 			server.URL+"/grpc.health.v1.Health/Watch",
 			connect.WithGRPC(),
 		)
-		if err != nil {
-			t.Fatalf(err.Error())
-		}
 		stream, err := client.CallServerStream(
 			context.Background(),
 			connect.NewRequest(&healthv1.HealthCheckRequest{Service: userFQN}),


### PR DESCRIPTION
Currently there is a conflict in including the same status protobuf due to the repository rename of `connect` to `connect-go`. The error when including `connect-go` and `connect-grpcreflect-go` results in the following failure:
```panic: proto: file "connectext/grpc/status/v1/status.proto" is already registered
	previously from: "github.com/bufbuild/connect/internal/gen/go/connectext/grpc/status/v1"
	currently from:  "github.com/bufbuild/connect-go/internal/gen/go/connectext/grpc/status/v1"
See https://developers.google.com/protocol-buffers/docs/reference/go/faq#namespace-conflict

```