### PR TITLE
Update comment to NewStaticChecker

### DIFF
--- a/grpchealth.go
+++ b/grpchealth.go
@@ -131,6 +131,10 @@ type StaticChecker struct {
 }
 
 // NewStaticChecker constructs a StaticChecker.
+//
+// The supplied strings should be fully-qualified protobuf service names (for
+// example, "acme.user.v1.UserService"). Generated connect service files
+// have this declared as a constant.
 func NewStaticChecker(services ...string) *StaticChecker {
 	set := make(map[string]struct{}, len(services))
 	for _, service := range services {

--- a/grpchealth.go
+++ b/grpchealth.go
@@ -133,7 +133,7 @@ type StaticChecker struct {
 // NewStaticChecker constructs a StaticChecker.
 //
 // The supplied strings should be fully-qualified protobuf service names (for
-// example, "acme.user.v1.UserService"). Generated connect service files
+// example, "acme.user.v1.UserService"). Generated Connect service files
 // have this declared as a constant.
 func NewStaticChecker(services ...string) *StaticChecker {
 	set := make(map[string]struct{}, len(services))


### PR DESCRIPTION
Mirrors: https://github.com/bufbuild/connect-grpcreflect-go/pull/12

Adding a call out to the Connect generated code on where to find the fully qualified name of the service