### PR TITLE
Prep for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,10 @@ func main() {
 
 ## Status
 
-Like [`connect-go`][connect-go], `connect-grpchealth-go` is a beta: we rely on
-it in production, but expect the Go community to quickly discover new patterns
-for working with generics. We plan to make backward-incompatible changes as
-necessary for the next few months, with the goal of tagging a stable v1 soon
-after the Go 1.19 release.
+Like [`connect-go`][connect-go], this module is a beta: we rely on it in
+production, but we may make a few changes as we gather feedback from early
+adopters. We're planning to tag a stable v1 in October, soon after the Go 1.19
+release.
 
 ## Support and Versioning
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ func main() {
 
 ## Status
 
-Like [`connect-go`][connect-go], `connect-grpchealth-go` is a release
-candidate. We plan to tag further release candidates as necessary and a stable
-v1 soon after the Go 1.19 release.
+Like [`connect-go`][connect-go], `connect-grpchealth-go` is a beta: we rely on
+it in production, but expect the Go community to quickly discover new patterns
+for working with generics. We plan to make backward-incompatible changes as
+necessary for the next few months, with the goal of tagging a stable v1 soon
+after the Go 1.19 release.
 
 ## Support and Versioning
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Offered under the [Apache 2 license][license].
 
 [APIv2]: https://blog.golang.org/protobuf-apiv2
 [Getting Started]: https://connect.build/go/getting-started
-[blog]: https://buf.build/blog/announcing-connect-a-better-grpc
+[blog]: https://buf.build/blog/connect-a-better-grpc
 [connect-go]: https://github.com/bufbuild/connect-go
 [demo]: https://github.com/bufbuild/connect-demo
 [docs]: https://connect.build

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/bufbuild/connect-grpchealth-go
 go 1.18
 
 require (
-	github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8
+	github.com/bufbuild/connect-go v0.1.0
 	google.golang.org/protobuf v1.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,8 @@
-github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8 h1:ZaD9cVYESl0sBAvcpmSO4wRbOSwS32F5wNPrnDw1XdE=
-github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8/go.mod h1:BajZGyRXK+Oq6Ddkm7atQ1Tu4W92OMpam7vyhFIf0ww=
+github.com/bufbuild/connect-go v0.1.0 h1:LxjZl0psAeiFuy3PIKoZpmixo3P6Dd+pLoy3QYVEAS0=
+github.com/bufbuild/connect-go v0.1.0/go.mod h1:4efZ2eXFENwd4p7tuLaL9m0qtTsCOzuBvrohvRGevDM=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=


### PR DESCRIPTION
Update README. Still pending dependency update after we tag a new
release of `connect-go`.
