### PR TITLE
Disable goimports lint, rely on GCI instead

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
+    - goimports         # rely on gci instead
     - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
     - ifshort           # deprecated by author


### PR DESCRIPTION
We're already using GCI (b/c we default to using all available linters),
so there's no need for goimports. We're doing this in core, buf, and our
other Go repos too.
