### PR TITLE
Fix GoDoc const grouping

### DIFF
--- a/grpchealth.go
+++ b/grpchealth.go
@@ -36,13 +36,13 @@ import (
 	healthv1 "github.com/bufbuild/connect-grpchealth-go/internal/gen/go/connectext/grpc/health/v1"
 )
 
+// HealthV1ServiceName is the fully-qualified name of the v1 version of the health service.
+const HealthV1ServiceName = "grpc.health.v1.Health"
+
 // Status describes the health of a service.
 type Status uint8
 
 const (
-	// HealthV1ServiceName is the fully-qualified name of the v1 version of the health service.
-	HealthV1ServiceName = "grpc.health.v1.Health"
-
 	// StatusUnknown indicates that the service's health state is indeterminate.
 	StatusUnknown Status = 0
 


### PR DESCRIPTION
The inscrutable logic that `pkg.go.dev` uses to group declarations
currently includes the service constant under the `Status` type, which
is clearly wrong. I suspect that moving it out of the block with the
actual status values will fix the issue.
